### PR TITLE
fix usage of commandLine from commit 65b2261

### DIFF
--- a/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
+++ b/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
@@ -67,9 +67,9 @@ class CalabashTestPlugin implements Plugin<Project> {
             def os = System.getProperty("os.name").toLowerCase()
             if (os.contains("windows")) {
                 // you start commands in Windows by kicking off a cmd shell
-                commandLine "cmd", "/c", "calabash-android", "run", "${apkFile}", "--format", "html", "--out", outFile.canonicalPath
+                testRunTask.commandLine "cmd", "/c", "calabash-android", "run", "${apkFile}", "--format", "html", "--out", outFile.canonicalPath
             }  else { // assume Linux 
-                commandLine "calabash-android", "run", "${apkFile}", "--format", "html", "--out", outFile.canonicalPath
+                testRunTask.commandLine "calabash-android", "run", "${apkFile}", "--format", "html", "--out", outFile.canonicalPath
             }
 
             testRunTask.doFirst {


### PR DESCRIPTION
previous commit broke the build - commandLine is a property of testRunTask
