### PR TITLE
Fix for SCREENSHOT_PATH env variable on MacOS.

### DIFF
--- a/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
+++ b/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
@@ -69,6 +69,7 @@ class CalabashTestPlugin implements Plugin<Project> {
                 // you start commands in Windows by kicking off a cmd shell
                 testRunTask.commandLine "cmd", "/c", "calabash-android", "run", "${apkFile}", "--format", "html", "--out", outFile.canonicalPath
             }  else { // assume Linux 
+                testRunTask.environment("SCREENSHOT_PATH", "${outFileDir}/")
                 testRunTask.commandLine "calabash-android", "run", "${apkFile}", "--format", "html", "--out", outFile.canonicalPath
             }
 


### PR DESCRIPTION
@kenyee Perhaps you could do it for Windows. I can't test that. This seems to work fine on MacOS.
