### PR TITLE
Added "-v" to calabash-android command line.

### DIFF
--- a/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
+++ b/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
@@ -67,9 +67,9 @@ class CalabashTestPlugin implements Plugin<Project> {
             def os = System.getProperty("os.name").toLowerCase()
             if (os.contains("windows")) {
                 // you start commands in Windows by kicking off a cmd shell
-                testRunTask.commandLine "cmd", "/c", "calabash-android", "run", "${apkFile}", "--format", "html", "--out", outFile.canonicalPath
+                testRunTask.commandLine "cmd", "/c", "calabash-android", "run", "${apkFile}", "--format", "html", "--out", outFile.canonicalPath, "-v"
             }  else { // assume Linux 
-                testRunTask.commandLine "calabash-android", "run", "${apkFile}", "--format", "html", "--out", outFile.canonicalPath
+                testRunTask.commandLine "calabash-android", "run", "${apkFile}", "--format", "html", "--out", outFile.canonicalPath, "-v"
             }
 
             testRunTask.doFirst {


### PR DESCRIPTION
See here for reason:
http://stackoverflow.com/questions/23243943/calabash-android-giving-no-keystores-found-when-run-under-jenkins
