### PR TITLE
Updated apkFilePath to new android studio convention

### DIFF
--- a/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
+++ b/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
@@ -26,7 +26,7 @@ class CalabashTestPlugin implements Plugin<Project> {
         def variants = hasAppPlugin ? project.android.applicationVariants :
                 project.android.libraryVariants
 
-        def apkFilePath = "$project.buildDir/apk"
+        def apkFilePath = "$project.buildDir/outputs/apk"
 
         variants.all { variant ->
             def buildTypeName = variant.buildType.name.capitalize()


### PR DESCRIPTION
New android studio projects are putting the generated apks in $project.buildDir/outputs/apk instead of $project.buildDir/apk, without this change the plugin crashes.
