### PR TITLE
Add support for cucumber report formats

### DIFF
--- a/src/main/groovy/org/notlocalhost/gradle/CalabashTestPluginExtension.groovy
+++ b/src/main/groovy/org/notlocalhost/gradle/CalabashTestPluginExtension.groovy
@@ -6,4 +6,5 @@ package org.notlocalhost.gradle
 class CalabashTestPluginExtension {
     String featuresPath
     String profile
+    String[] formats
 }

--- a/src/test/groovy/org/notlocalhost/gradle/CalabashTestPluginTest.groovy
+++ b/src/test/groovy/org/notlocalhost/gradle/CalabashTestPluginTest.groovy
@@ -58,4 +58,22 @@ class CalabashTestPluginTest {
 
       Assertions.assertThat(commandArguments.contains("expectedProfile")).isTrue();
   }
+
+  @Test public void pluginGetsFormatsFromGradleBuildFileWhenAvailable() {
+      CalabashTestPlugin plugin = new CalabashTestPlugin();
+
+      String apkFile = "TestApkFile";
+      File outFile = new File("/File/Path");
+      Project project = ProjectBuilder.builder().build();
+
+      project.extensions.create("calabashTest", CalabashTestPluginExtension)
+
+      project.calabashTest.formats = ["html", "json"]
+
+      Iterable commandArguments = plugin.constructCommandLineArguments(project, apkFile, outFile);
+
+      Assertions.assertThat(commandArguments.contains("--format")).isTrue();
+      Assertions.assertThat(commandArguments.contains("html")).isTrue();
+      Assertions.assertThat(commandArguments.contains("json")).isTrue();
+  }
 }


### PR DESCRIPTION
Especially when used in a Continuous Integration environment, it is key
to allow other cucumber report formats such as 'json'. Having to provide
a config/cucumber.yml file in an Android project isn't really fancy.
Providing this directly as a gradle plugin config option is much nicer.
