### PR TITLE
#18 Added support for deploying to mavenLocal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 apply plugin: 'groovy'
 apply plugin: 'maven'
-apply plugin: 'nexus'
+apply plugin: 'signing'
 
 group = 'org.notlocalhost.gradle'
 version = '1.3-SNAPSHOT'
@@ -28,49 +28,68 @@ dependencies {
   testCompile 'org.easytesting:fest-assert-core:2.0M10'
 }
 
-install {
-  repositories.mavenInstaller {
-    pom.artifactId = 'gradle-calabash-android-plugin'
-  }
+project.afterEvaluate {
+    project.uploadArchives {
+        repositories {
+            mavenDeployer {
+                configuration = project.configurations.archives
+                beforeDeployment { MavenDeployment deployment -> project.signing.signPom(deployment) }
+
+                String repoUser = getRepositoryUsername(project);
+                String repoPass = getRepositoryPassword(project);
+                String snapshotUrl = repoUser.isEmpty() ? mavenLocal().url : "https://oss.sonatype.org/content/repositories/snapshots/"
+
+                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                    authentication(userName: repoUser, password: repoPass)
+                }
+
+                snapshotRepository(url: snapshotUrl) {
+                    authentication(userName: repoUser, password: repoPass)
+                }
+
+                pom.artifactId = 'gradle-calabash-android-plugin'
+                pom.project {
+                    name 'Gradle Calabash Test Plugin'
+                    description "A Gradle plugin which enables Calabash Testing"
+                    url 'https://github.com/pedlar/gradle-calabash-android-plugin'
+                    inceptionYear '2013'
+
+                    scm {
+                        url 'https://github.com/pedlar/gradle-calabash-android-plugin'
+                        connection 'scm:git:git://github.com/pedlar/gradle-calabash-android-plugin.git'
+                        developerConnection 'scm:git:ssh://git@github.com/pedlar/gradle-calabash-android-plugin.git'
+                    }
+
+                    licenses {
+                        license {
+                            name 'The Apache Software License, Version 2.0'
+                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            distribution 'repo'
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id 'pedlar'
+                            name 'Pedlar'
+                            email 'pedlar88@gmail.com'
+                        }
+                    }
+
+                    organization {
+                        name 'NotLocalHost'
+                        url 'http://notlocalhost.org'
+                    }
+                }
+            }
+        }
+    }
 }
-uploadArchives {
-  repositories.mavenDeployer {
-    pom.artifactId = 'gradle-calabash-android-plugin'
-  }
+
+private static String getRepositoryUsername(Project project) {
+    return project.hasProperty('nexusUsername') ? project.nexusUsername : ""
 }
 
-modifyPom {
-  project {
-    name 'Gradle Calabash Test Plugin'
-    description "A Gradle plugin which enables Calabash Testing"
-    url 'https://github.com/pedlar/gradle-calabash-android-plugin'
-    inceptionYear '2013'
-
-    scm {
-      url 'https://github.com/pedlar/gradle-calabash-android-plugin'
-      connection 'scm:git:git://github.com/pedlar/gradle-calabash-android-plugin.git'
-      developerConnection 'scm:git:ssh://git@github.com/pedlar/gradle-calabash-android-plugin.git'
-    }
-
-    licenses {
-      license {
-        name 'The Apache Software License, Version 2.0'
-        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-        distribution 'repo'
-      }
-    }
-
-    developers {
-      developer {
-        id 'pedlar'
-        name 'Pedlar'
-        email 'pedlar88@gmail.com'
-      }
-    }
-
-    organization {
-      name 'NotLocalHost'
-      url 'http://notlocalhost.org'
-    }
-  }
+private static String getRepositoryPassword(Project project) {
+    return project.hasProperty('nexusPassword') ? project.nexusPassword : ""
 }


### PR DESCRIPTION
Deployment to Nexus should still work on systems with a username/password and signing uses the default signing config configured on the system for release builds. The pom configuration remains unchanged.
