### PR TITLE
#22 Removed windows exclusion for setting screenshot directory

### DIFF
--- a/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
+++ b/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
@@ -69,9 +69,7 @@ class CalabashTestPlugin implements Plugin<Project> {
 
             Iterable commandArguments = constructCommandLineArguments(project, apkFile, outFileDir)
 
-            if (!os.contains("windows")) { // assume Linux
-                testRunTask.environment("SCREENSHOT_PATH", "${outFileDir}/")
-            }
+            testRunTask.environment("SCREENSHOT_PATH", "${outFileDir}/")
 
             testRunTask.commandLine commandArguments
 


### PR DESCRIPTION
- Screenshots now reside next to the output reports.
