### PR TITLE
use archivesBaseName instead of project name

### DIFF
--- a/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
+++ b/src/main/groovy/org/notlocalhost/gradle/CalabashTestPlugin.groovy
@@ -44,9 +44,9 @@ class CalabashTestPlugin implements Plugin<Project> {
 
             def apkName = ""
             if(projectFlavorName != "") {
-                apkName = "${project.name}-${projectFlavorName.toLowerCase()}-${buildTypeName.toLowerCase()}-unaligned.apk"
+                apkName = "${project.archivesBaseName}-${projectFlavorName.toLowerCase()}-${buildTypeName.toLowerCase()}-unaligned.apk"
             } else {
-                apkName = "${project.name}-${buildTypeName.toLowerCase()}-unaligned.apk"
+                apkName = "${project.archivesBaseName}-${buildTypeName.toLowerCase()}-unaligned.apk"
             }
 
             project.logger.debug "==========================="


### PR DESCRIPTION
#25 Fix apk not being found if archive base name is used to change the apk name.
